### PR TITLE
User modern (v2) node package lock format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -244,7 +244,8 @@
       "dependencies": {
         "bootstrap": "^5.1.3",
         "maplibre-gl": ">=1.15.2"
-      }
+      },
+      "name": "digiplan"
     },
     "node_modules/@mapbox/geojson-rewind": {
       "bin": {

--- a/package.json
+++ b/package.json
@@ -2,5 +2,6 @@
   "dependencies": {
     "bootstrap": "^5.1.3",
     "maplibre-gl": ">=1.15.2"
-  }
+  },
+  "name": "digiplan"
 }


### PR DESCRIPTION
Hi @henhuy,

I use the current LTS version v16.x of `node` and the v8.x of `npm` that comes with it. If I now install the dependencies via `npm install` my npm version forces a rewrite of the lock file into the current (v2) version.

I assume, you use an older version of `node` \ `npm` and therefore recommend, that you update to the [current LTS version](https://nodejs.org/en/) (v16.x).

If you need multiple version of `node` on your system installed, I recommend you use [`nvm`](https://github.com/nvm-sh/nvm) (Node Version Manager) for managing multiple instances of `node` on your system.

If you agree with using the current LTS version of Node in this project, please review and merge this PR (if you approve) - thank you!

PS: I had to set a `name` attribute with value "digiplan" in the `package.json`, otherwise `npm` would force set a `name` attribute in the `package-lock.json` based on the project's pathname (which in my case is "git").