### PR TITLE
fix steps view to be clickable

### DIFF
--- a/digiplan/static/scss/components/_top-nav.scss
+++ b/digiplan/static/scss/components/_top-nav.scss
@@ -53,11 +53,9 @@
     @extend .bg-white;
     @extend .text-center;
     @extend .fw-bold;
-    z-index: -2;
 
     &.active {
       @extend .text-info;
-      z-index: -2;
     }
 
     &.disabled {


### PR DESCRIPTION
Sorry for this, but I saw after my last PR #57 has been merged into dev that the steps below the top navigation were not clickable anymore. Very simple issue: their z-index was not correct. It should be fixed now (I hope)!