### PR TITLE
Extend popup schema with key values component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - results layer with customizable result views
 
 ### Changed
+- extend popup schema with key values component
 - load satellite layer beneath symbol layers #43
 - switch top left logo for final version
 - switch to Digiplan favicon set

--- a/config/schemas.py
+++ b/config/schemas.py
@@ -18,6 +18,12 @@ with open(os.path.join(COMPONENTS_DIR, "chart.schema.json"), "rb") as f:
 with open(os.path.join(COMPONENTS_DIR, "chart.example.json"), "rb") as f:
     CHART_EXAMPLE = json.loads(f.read())
 
+with open(os.path.join(COMPONENTS_DIR, "key-values.schema.json"), "rb") as f:
+    KEY_VALUES_SCHEMA = json.loads(f.read())
+
+with open(os.path.join(COMPONENTS_DIR, "key-values.example.json"), "rb") as f:
+    KEY_VALUES_EXAMPLE = json.loads(f.read())
+
 with open(os.path.join(COMPONENTS_DIR, "sources.schema.json"), "rb") as f:
     SOURCES_SCHEMA = json.loads(f.read())
 

--- a/digiplan/schemas/components/key-values.example.json
+++ b/digiplan/schemas/components/key-values.example.json
@@ -1,0 +1,7 @@
+{
+  "municipalityValue": 9311,
+  "regionTitle": "ABW region",
+  "regionValue": 370190,
+  "unit": "Population",
+  "year": 2022
+}

--- a/digiplan/schemas/components/key-values.schema.json
+++ b/digiplan/schemas/components/key-values.schema.json
@@ -1,0 +1,36 @@
+{
+  "$id": "https://wam.rl-institut.de/digiplan/schemas/components/key-values.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Key values for concerning municipality in comparison with ABW region",
+  "properties": {
+    "municipalityValue": {
+      "description": "Value for Municipality",
+      "type": "number"
+    },
+    "regionTitle": {
+      "description": "Title for region, e.g.: AWB region",
+      "type": "string"
+    },
+    "regionValue": {
+      "description": "Value for Municipality",
+      "type": "number"
+    },
+    "unit": {
+      "description": "Human readable name for unit in question, e.g.: population, kW/h, GW, etc.",
+      "type": "string"
+    },
+    "year": {
+      "description": "Year of key indicator values in question",
+      "type": "number"
+    }
+  },
+  "required": [
+    "unit",
+    "year",
+    "municipalityValue",
+    "regionTitle",
+    "regionValue"
+  ],
+  "type": "object"
+}

--- a/digiplan/schemas/popup.example.json
+++ b/digiplan/schemas/popup.example.json
@@ -33,6 +33,13 @@
   },
   "description": "The population in 2022 of Z\u00f6rbig was 9,311 inhabitants. The entire ABW region had 370,190 inhabitants at that time. The following chart shows a forecast of the population development for the years 2022, 2030, and 2045.",
   "id": 12,
+  "keyValues": {
+    "municipalityValue": 9311,
+    "regionTitle": "ABW region",
+    "regionValue": 370190,
+    "unit": "Population",
+    "year": 2022
+  },
   "municipality": "Z\u00f6rbig",
   "sources": [
     {

--- a/digiplan/schemas/popup.schema.json
+++ b/digiplan/schemas/popup.schema.json
@@ -16,6 +16,9 @@
       "description": "ID of the entry",
       "type": "integer"
     },
+    "keyValues": {
+      "$ref": "https://wam.rl-institut.de/digiplan/schemas/components/key-values.schema.json"
+    },
     "municipality": {
       "description": "Name of the municipality",
       "maxLength": 50,
@@ -34,6 +37,7 @@
     "chart",
     "description",
     "id",
+    "keyValues",
     "municipality",
     "sources",
     "title"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -13,6 +13,15 @@ def test_if_chart_example_validates():
     assert jsonschema.validate(CHART_EXAMPLE, CHART_SCHEMA) is None  # noqa: S101
 
 
+def test_if_key_values_example_validates():
+    import jsonschema
+
+    from config.schemas import KEY_VALUES_SCHEMA  # noqa: I001
+    from config.schemas import KEY_VALUES_EXAMPLE  # noqa: I001
+
+    assert jsonschema.validate(KEY_VALUES_EXAMPLE, KEY_VALUES_SCHEMA) is None  # noqa: S101
+
+
 def test_if_sources_example_validates():
     import jsonschema
 
@@ -29,12 +38,14 @@ def test_if_popup_example_validates():
     from jsonschema import Draft202012Validator, RefResolver
 
     from config.schemas import CHART_SCHEMA  # noqa: I001
+    from config.schemas import KEY_VALUES_SCHEMA  # noqa: I001
     from config.schemas import POPUP_SCHEMA  # noqa: I001
     from config.schemas import POPUP_EXAMPLE  # noqa: I001
     from config.schemas import SOURCES_SCHEMA  # noqa: I001
 
     schema_store = {
         CHART_SCHEMA["$id"]: CHART_SCHEMA,
+        KEY_VALUES_SCHEMA["$id"]: KEY_VALUES_SCHEMA,
         POPUP_SCHEMA["$id"]: POPUP_SCHEMA,
         SOURCES_SCHEMA["$id"]: SOURCES_SCHEMA,
     }


### PR DESCRIPTION
Hi @henhuy, please review this PR and merge on approval.

@bmlancien introduced in #73 a revised popup with a new section that I would call "key values":

![image](https://user-images.githubusercontent.com/3404313/196450808-9efc57ab-bcdc-4690-999f-8d030eba4093.png)

Therefore I created a new key values schema and embedded it into given popup schema and tests.

IMO this key values section can be used super generically for population, kw/h, GW, etc.