### PR TITLE
Make local Docker run, by adding missing default value on PROJ_LIB env var check in settings

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -231,7 +231,7 @@ COMPRESS_CACHEABLE_PRECOMPILERS = (("text/x-scss", "django_libsass.SassCompiler"
 # ------------------------------------------------------------------------------
 
 # If given, use local PROJ_LIB environment variable
-if env("PROJ_LIB"):
+if env("PROJ_LIB", default=False):
     PROJ_LIB = env("PROJ_LIB")
 
 DISTILL = env.bool("DISTILL", False)


### PR DESCRIPTION
Hi @bmlancien, @henhuy, either of you can review this. First comes, first served. Please review and merge on approval.

Yesterday, @bmlancien had a problem, that he could not run Docker locally:

`django.core.exceptions.ImproperlyConfigured: Set the PROJ_LIB environment variable`

After minor digging, I found that there was simply a default return value missing in the PROJECT_LIB environment variable check in the settings in `base.py.`

This PR fixes that.

@bmlancien, after this PR is merged, you should be able to work locally with Docker on your machine.