### PR TITLE
Power-mix chart design

### DIFF
--- a/digiplan/static/js/sliders.js
+++ b/digiplan/static/js/sliders.js
@@ -138,12 +138,15 @@ function getColorsByIds(ids) {
 function updatePowerMix(weights, colors) {
   const msg = "Unequal amount of weights and colors";
   if (weights.length !== colors.length) throw new Error(msg);
-  let html = "";
-
+  let html = `<div class="power-mix__chart"><div class="power-mix__icons">`;
   for (const index of weights.keys()) {
-    html += `<span style="width: ${weights[index]}%; background-color: ${colors[index]}; text-align: center; height: 1rem;"></span>`;
+    html += `<div style="width: ${weights[index]}%;"><svg width="16" height="16" version="1.1" fill="currentColor" viewBox="0 0 16.933 16.933" xmlns="http://www.w3.org/2000/svg"><path d="m4.3692 1.0589-3.4923 11.64h0.71107 2.6443v3.176h1.0589v-3.176h6.3516v3.176h1.0563v-3.176h3.3574l-3.4918-11.64h-8.1954zm0.78703 1.0583h2.7812v2.1151h-3.4163l0.6351-2.1151zm3.8401 0h2.7812l0.6351 2.1151h-3.4163v-2.1151zm-4.793 3.174h3.7341v2.1172h-4.3692l0.6351-2.1172zm4.793 0h3.7341l0.6351 2.1172h-4.3692v-2.1172zm-5.7459 3.1755h4.6871v3.176h-5.6405l0.95343-3.176zm5.7459 0h4.6871l0.95343 3.176h-5.6405v-3.176z"/></svg></div>`;
   }
-
+  html += `</div><div class="power-mix__colors">`;
+  for (const index of weights.keys()) {
+    html += `<div style="width: ${weights[index]}%; background-color: ${colors[index]}; text-align: center; height: 1rem;"></div>`;
+  }
+  html += `</div></div>`;
   powerMixInfoBanner.innerHTML = html;
 }
 

--- a/digiplan/static/scss/components/_charts.scss
+++ b/digiplan/static/scss/components/_charts.scss
@@ -9,3 +9,36 @@
   width: 100%;
   height: 300px;
 }
+
+
+
+.power-mix {
+  @extend .position-relative;
+  @extend .d-flex;
+  @extend .flex-row;
+  @extend .py-2;
+  @extend .px-3;
+
+  &__chart {
+    @extend .d-flex;
+    @extend .flex-column;
+    @extend .w-100;
+  }
+
+  &__icons {
+    @extend .d-flex;
+    @extend .flex-row;
+    @extend .w-100;
+
+    & > div {
+      @extend .mb-1;
+      @extend .text-center;
+      height:1rem;
+    }
+  }
+
+  &__colors {
+    @extend .d-flex;
+    @extend .flex-row;
+  }
+}

--- a/digiplan/templates/components/panel_2_settings.html
+++ b/digiplan/templates/components/panel_2_settings.html
@@ -37,7 +37,7 @@
       </ul>
       <div class="c-tabs__content">
         <div class="c-tabs__pane fade show active" id="wind" role="tabpanel" aria-labelledby="wind-tab">
-          <div id="js-power-mix" class="my-2 px-4" style="display: flex;"></div>
+          <div id="js-power-mix" class="power-mix"></div>
           {{energy_settings_panel}}
         </div>
         <div class="c-tabs__pane fade" id="heat" role="tabpanel" aria-labelledby="heat-tab">


### PR DESCRIPTION
I added icon placeholders to the power-mix graph in order to see how it could look like in real. Obviously it's not ideal since they can overlap, but it's still better, I would say, than no icons at all, as it makes difficult to recognise. I would add the technology name on hover too. Maybe, before merging this, we could show this on next meeting and decide what to do...?