### PR TITLE
make main view vertically scrollable if content exceeds view height

### DIFF
--- a/digiplan/static/scss/components/_map.scss
+++ b/digiplan/static/scss/components/_map.scss
@@ -26,7 +26,9 @@
 }
 
 #mainTabContent {
+  @extend .bg-light;
   height: $map-height;
+  overflow-y: auto;
 }
 
 #map {

--- a/digiplan/static/scss/layouts/_results.scss
+++ b/digiplan/static/scss/layouts/_results.scss
@@ -1,7 +1,6 @@
 .results {
   @extend .h-100;
   @extend .w-100;
-  @extend .bg-light;
   @extend .p-5;
   padding-top: 6rem !important;
 
@@ -11,6 +10,7 @@
 
   &__item {
     @extend .col-xl-6;
+    @extend .pb-5;
   }
 
   &__chart {


### PR DESCRIPTION
I saw this bug on the results view with a smaller window. The charts content was partly hidden, but instead of vertically scrolling only this view, it also was scrolling the left side panel together. Now the side panel should stay fixed and only the charts view should be scrollable.

Close #140 