### PR TITLE
Refactored clustered layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - legend for choropleths
 - CONTRIBUTING.md file
 
-### Fixed
-- choropleth and schema tests
+### Changed
+- implementation of clustered layers
 
 ### Fixed
+- choropleth and schema tests
 - migration conflict
 
 ## [0.1.0] - 2023-02-10

--- a/digiplan/map/config/config.py
+++ b/digiplan/map/config/config.py
@@ -29,6 +29,7 @@ DEPENDENCY_PARAMETERS_FILE = settings.APPS_DIR.path("static/config/dependency_pa
 MIN_ZOOM = 8
 MAX_ZOOM = 22
 MAX_DISTILLED_ZOOM = 10
+DEFAULT_CLUSTER_ZOOM = 11
 
 Zoom = namedtuple("MinMax", ["min", "max"])
 ZOOM_LEVELS = {

--- a/digiplan/map/mapset/setup.py
+++ b/digiplan/map/mapset/setup.py
@@ -8,12 +8,12 @@ from digiplan.map.config import config
 from digiplan.map.mapset import layers, sources, utils
 
 STATIC_LAYERS = {
-    "wind": layers.StaticLayer(id="wind", model=models.WindTurbine, type="circle", source="static"),
-    "pvroof": layers.StaticLayer(id="pvroof", model=models.PVroof, type="circle", source="static"),
-    "pvground": layers.StaticLayer(id="pvground", model=models.PVground, type="circle", source="static"),
-    "hydro": layers.StaticLayer(id="hydro", model=models.Hydro, type="circle", source="static"),
-    "biomass": layers.StaticLayer(id="biomass", model=models.Biomass, type="circle", source="static"),
-    "combustion": layers.StaticLayer(id="combustion", model=models.Combustion, type="circle", source="static"),
+    "wind": layers.ClusterModelLayer(id="wind", model=models.WindTurbine, type="circle", source="static"),
+    "pvroof": layers.StaticModelLayer(id="pvroof", model=models.PVroof, type="circle", source="static"),
+    "pvground": layers.StaticModelLayer(id="pvground", model=models.PVground, type="circle", source="static"),
+    "hydro": layers.StaticModelLayer(id="hydro", model=models.Hydro, type="circle", source="static"),
+    "biomass": layers.StaticModelLayer(id="biomass", model=models.Biomass, type="circle", source="static"),
+    "combustion": layers.StaticModelLayer(id="combustion", model=models.Combustion, type="circle", source="static"),
 }
 
 
@@ -21,7 +21,7 @@ STATIC_LAYERS = {
 class LegendLayer:
     name: str
     description: str
-    layer: layers.StaticLayer
+    layer: layers.ModelLayer
     color: Optional[str] = None
 
     def get_color(self):
@@ -51,8 +51,9 @@ RESULT_LAYERS = [
         source="results",
         source_layer="results",
         style=config.LAYER_STYLES["results"],
-    )
+    ),
 ]
+
 
 # Order is important! Last items are shown on top!
 ALL_LAYERS = REGION_LAYERS + RESULT_LAYERS + DYNAMIC_LAYERS
@@ -89,15 +90,12 @@ SOURCES += [
         "satellite",
         type="raster",
         tiles=[
-            f"https://api.maptiler.com/tiles/satellite-v2/{{z}}/{{x}}/{{y}}.jpg?key={settings.TILING_SERVICE_TOKEN}",
+            f"https://api.maptiler.com/tiles/satellite-v2/{{z}}/{{x}}/{{y}}.jpg?key={settings.TILING_SERVICE_TOKEN}"
         ],
     ),
-    sources.MapSource("cluster", type="geojson", url="clusters"),
+    sources.MapSource("wind", type="geojson", url="clusters/wind.geojson", cluster=True),
     sources.MapSource(name="static", type="vector", tiles=["static_mvt/{z}/{x}/{y}/"]),
-    sources.MapSource(
-        name="static_distilled",
-        type="vector",
-        tiles=["static/mvts/{z}/{x}/{y}/static.mvt"],
-    ),
+    sources.MapSource(name="static_distilled", type="vector", tiles=["static/mvts/{z}/{x}/{y}/static.mvt"]),
     sources.MapSource(name="results", type="vector", tiles=["results_mvt/{z}/{x}/{y}/"]),
-] + sources.get_dynamic_sources(LAYERS_DEFINITION)
+    *sources.get_dynamic_sources(LAYERS_DEFINITION),
+]

--- a/digiplan/map/urls.py
+++ b/digiplan/map/urls.py
@@ -4,9 +4,10 @@
 from django.conf import settings
 from django.urls import path
 from django_distill import distill_path
+from djgeojson.views import GeoJSONLayerView
 
 from digiplan.map.config.config import get_tile_coordinates_for_region
-from digiplan.map.mapset import mvt_layers
+from digiplan.map.mapset import mvt_layers, setup
 
 from . import views
 from .mvt import mvt_view_factory
@@ -15,10 +16,14 @@ app_name = "map"
 
 urlpatterns = [
     path("", views.MapGLView.as_view(), name="map"),
-    path("clusters", views.get_clusters, name="clusters"),
     path("choropleth/<str:lookup>/<str:scenario>", views.get_choropleth, name="choropleth"),
     path("visualization", views.get_visualization, name="visualization"),
     path("popup/<str:lookup>/<int:region>", views.get_popup, name="popup"),
+]
+
+urlpatterns += [
+    path(f"clusters/{name}.geojson", GeoJSONLayerView.as_view(model=cluster_layer.model))
+    for name, cluster_layer in setup.STATIC_LAYERS.items()
 ]
 
 urlpatterns += [

--- a/digiplan/static/config/layer_styles.json
+++ b/digiplan/static/config/layer_styles.json
@@ -94,6 +94,36 @@
       ]
     }
   },
+  "wind_cluster": {
+    "paint": {
+      "circle-color": [
+        "step",
+        ["get", "point_count"],
+        "#51bbd6",
+        100,
+        "#f1f075",
+        750,
+        "#f28cb1"
+      ],
+      "circle-radius": [
+        "step",
+        ["get", "point_count"],
+        20,
+        100,
+        30,
+        750,
+        40
+      ]
+    }
+  },
+  "wind_cluster_count": {
+    "filter": ["has", "point_count"],
+    "layout": {
+      "text-field": "{point_count_abbreviated}",
+      "text-font": ["DIN Offc Pro Medium", "Arial Unicode MS Bold"],
+      "text-size": 12
+    }
+  },
   "pvroof": {
     "paint": {
       "circle-color": "#FFD660",

--- a/digiplan/templates/map.html
+++ b/digiplan/templates/map.html
@@ -132,67 +132,6 @@
         });
       {% endfor %}
 
-      PubSub.subscribe(eventTopics.MAP_SOURCES_LOADED, add_cluster_layers);
-
-      function add_cluster_layers(msg) {
-        {% if layer.clustered %}
-          // Clustered layer
-          {% for level, zoom in zoom_levels.items %}
-            map.addLayer({
-              id: "{{layer.source_layer}}_{{level}}",
-              type: "circle",
-              source: "clusters",
-              minzoom: {{zoom.min}},
-              maxzoom: {{zoom.max}},
-              filter: ["==", ["get", "zoom_level"], {{zoom.max}}],
-              paint: {
-                // Use step expressions (https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-step)
-                // with three steps to implement three types of circles:
-                //   * Blue, 20px circles when point count is less than 100
-                //   * Yellow, 30px circles when point count is between 100 and 750
-                //   * Pink, 40px circles when point count is greater than or equal to 750
-                "circle-color": [
-                  "step",
-                  ["get", "{{layer.source_layer}}"],
-                  "#51bbd6",
-                  100,
-                  "#f1f075",
-                  750,
-                  "#f28cb1"
-                ],
-                "circle-radius": [
-                  "step",
-                  ["get", "{{layer.source_layer}}"],
-                  20,
-                  100,
-                  30,
-                  750,
-                  40
-                ]
-              }
-            });
-            map.addLayer(
-              {
-                id: "{{layer.source_layer}}_counter_{{level}}",
-                type: "symbol",
-                source: "clusters",
-                minzoom: {{zoom.min}},
-                maxzoom: {{zoom.max}},
-                filter: ["==", ["get", "zoom_level"], {{zoom.max}}],
-                layout: {
-                  "text-field": ["get", "{{layer.source_layer}}"],
-                  "text-font": ["DIN Offc Pro Medium", "Arial Unicode MS Bold"],
-                  "text-size": 12,
-                  "text-allow-overlap": true
-                }
-              }
-            );
-            map.setLayoutProperty("{{layer.source_layer}}_{{level}}", "visibility", "none");
-            map.setLayoutProperty("{{layer.source_layer}}_counter_{{level}}", "visibility", "none");
-          {% endfor %}
-        {% endif %}
-      }
-
       // Zoom to feature on click
       map.on("click", function (element) {
         flyToElement(element);

--- a/digiplan/utils/data_processing.py
+++ b/digiplan/utils/data_processing.py
@@ -7,7 +7,7 @@ from geojson import Feature, FeatureCollection, Point
 
 from config.settings.base import DATA_DIR
 from digiplan.map.config.config import CLUSTER_GEOJSON_FILE, ZOOM_LEVELS
-from digiplan.map.mapset.layers import StaticLayer
+from digiplan.map.mapset.layers import StaticModelLayer
 from digiplan.map.mapset.setup import LAYERS_DEFINITION
 from digiplan.map.models import (
     Biomass,
@@ -89,12 +89,15 @@ def load_population():
                 continue
 
             entry = Population(
-                year=year, value=value, entry_type=list(series.index.values)[0], municipality=municipality
+                year=year,
+                value=value,
+                entry_type=list(series.index.values)[0],
+                municipality=municipality,
             )
             entry.save()
 
 
-def build_cluster_geojson(cluster_layers: list[StaticLayer] = None):
+def build_cluster_geojson(cluster_layers: list[StaticModelLayer] = None):
     cluster_layers = cluster_layers or LAYERS_DEFINITION
     features = []
     for region_model in REGIONS:


### PR DESCRIPTION
Clustered layers are created from Models using django-geojson.
3 cluster layers are added: 
- cluster: painting circles, where color and size depends on cluster size
- cluster_count: paints number of cluster size into circle
- unclustered: paints a default symbol for single occurences