### PR TITLE
Feature/#337 remove main chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - remove language button
 - rework result charts
 - rework top navigation and linked pages
+- hide main charts in today and result section
 
 ### Fixed
 - slider mark at wrong position

--- a/digiplan/static/js/charts.js
+++ b/digiplan/static/js/charts.js
@@ -1,12 +1,12 @@
 // Goals & scenarios, initioalize charts
-const renewable_share_goal_div = document.getElementById("renewable_share_goal_chart");
-const renewable_share_goal_chart = echarts.init(renewable_share_goal_div);
-const co2_emissions_goal_div = document.getElementById("co2_emissions_goal_chart");
-const co2_emissions_goal_chart = echarts.init(co2_emissions_goal_div);
-const renewable_share_scenario_div = document.getElementById("renewable_share_scenario_chart");
-const renewable_share_scenario_chart = echarts.init(renewable_share_scenario_div);
-const co2_emissions_scenario_div = document.getElementById("co2_emissions_scenario_chart");
-const co2_emissions_scenario_chart = echarts.init(co2_emissions_scenario_div);
+// const renewable_share_goal_div = document.getElementById("renewable_share_goal_chart");
+// const renewable_share_goal_chart = echarts.init(renewable_share_goal_div);
+// const co2_emissions_goal_div = document.getElementById("co2_emissions_goal_chart");
+// const co2_emissions_goal_chart = echarts.init(co2_emissions_goal_div);
+// const renewable_share_scenario_div = document.getElementById("renewable_share_scenario_chart");
+// const renewable_share_scenario_chart = echarts.init(renewable_share_scenario_div);
+// const co2_emissions_scenario_div = document.getElementById("co2_emissions_scenario_chart");
+// const co2_emissions_scenario_chart = echarts.init(co2_emissions_scenario_div);
 
 // Results view, initiliaze charts
 // const detailed_overview_chart = echarts.init(document.getElementById("detailed_overview_chart"));
@@ -287,10 +287,10 @@ const ghg_reduction_option = JSON.parse(document.getElementById("ghg_reduction")
 
 function resizeCharts() {
   setTimeout(function () {
-    renewable_share_goal_chart.resize();
-    co2_emissions_goal_chart.resize();
-    renewable_share_scenario_chart.resize();
-    co2_emissions_scenario_chart.resize();
+    // renewable_share_goal_chart.resize();
+    // co2_emissions_goal_chart.resize();
+    // renewable_share_scenario_chart.resize();
+    // co2_emissions_scenario_chart.resize();
     // detailed_overview_chart.resize();
     // ghg_overview_chart.resize();
     electricity_overview_chart.resize();
@@ -305,10 +305,10 @@ function resizeCharts() {
 }
 
 // Goals & scenarios, setOptions
-renewable_share_goal_chart.setOption(renewable_share_goal);
-co2_emissions_goal_chart.setOption(co2_emissions_goal);
-renewable_share_scenario_chart.setOption(renewable_share_scenario);
-co2_emissions_scenario_chart.setOption(co2_emissions_scenario);
+// renewable_share_goal_chart.setOption(renewable_share_goal);
+// co2_emissions_goal_chart.setOption(co2_emissions_goal);
+// renewable_share_scenario_chart.setOption(renewable_share_scenario);
+// co2_emissions_scenario_chart.setOption(co2_emissions_scenario);
 
 // Results, setOptions
 // detailed_overview_chart.setOption(detailed_overview_option);

--- a/digiplan/templates/components/panel_1_today.html
+++ b/digiplan/templates/components/panel_1_today.html
@@ -1,28 +1,28 @@
 {% load static i18n %}
 
-<div class="panel__goal">
-<!--  <div class="panel__goal-header">-->
-<!--    <span>{% translate "Goals 2045" %}</span>-->
+<!--<div class="panel__goal">-->
+<!--&lt;!&ndash;  <div class="panel__goal-header">&ndash;&gt;-->
+<!--&lt;!&ndash;    <span>{% translate "Goals 2045" %}</span>&ndash;&gt;-->
+<!--&lt;!&ndash;  </div>&ndash;&gt;-->
+<!--  <div class="panel__charts">-->
+<!--    <div class="panel__chart">-->
+<!--      <div class="panel__chart-title">-->
+<!--        {% translate "Anteil EE am Stromverbrauch" %} (%)-->
+<!--      </div>-->
+<!--      <div class="panel__chart-content">-->
+<!--        <div id="renewable_share_goal_chart" class="goal-chart"></div>-->
+<!--      </div>-->
+<!--    </div>-->
+<!--    <div class="panel__chart">-->
+<!--      <div class="panel__chart-title">-->
+<!--        {% translate "THG-Reduktion ggü. 2019 (%)" %}-->
+<!--      </div>-->
+<!--      <div class="panel__chart-content">-->
+<!--        <div id="co2_emissions_goal_chart" class="goal-chart"></div>-->
+<!--      </div>-->
+<!--    </div>-->
 <!--  </div>-->
-  <div class="panel__charts">
-    <div class="panel__chart">
-      <div class="panel__chart-title">
-        {% translate "Anteil EE am Stromverbrauch" %} (%)
-      </div>
-      <div class="panel__chart-content">
-        <div id="renewable_share_goal_chart" class="goal-chart"></div>
-      </div>
-    </div>
-    <div class="panel__chart">
-      <div class="panel__chart-title">
-        {% translate "THG-Reduktion ggü. 2019 (%)" %}
-      </div>
-      <div class="panel__chart-content">
-        <div id="co2_emissions_goal_chart" class="goal-chart"></div>
-      </div>
-    </div>
-  </div>
-</div>
+<!--</div>-->
 <div class="panel__settings panel__settings--padding">
   <div class="panel-item">
     <h2 class="panel-item__heading panel-item__heading--nopadding">

--- a/digiplan/templates/components/panel_3_results.html
+++ b/digiplan/templates/components/panel_3_results.html
@@ -1,25 +1,25 @@
 {% load static i18n %}
 
-<div class="panel__goal">
-  <div class="panel__charts">
-    <div class="panel__chart">
-      <div class="panel__chart-title">
-        {% translate "Anteil EE am Stromverbrauch" %} (%)
-      </div>
-      <div class="panel__chart-content">
-        <div id="renewable_share_scenario_chart" class="goal-chart"></div>
-      </div>
-    </div>
-    <div class="panel__chart">
-      <div class="panel__chart-title">
-       {% translate "THG-Reduktion ggü. 2019 (%)" %}
-      </div>
-      <div class="panel__chart-content">
-        <div id="co2_emissions_scenario_chart" class="goal-chart"></div>
-      </div>
-    </div>
-  </div>
-</div>
+<!--<div class="panel__goal">-->
+<!--  <div class="panel__charts">-->
+<!--    <div class="panel__chart">-->
+<!--      <div class="panel__chart-title">-->
+<!--        {% translate "Anteil EE am Stromverbrauch" %} (%)-->
+<!--      </div>-->
+<!--      <div class="panel__chart-content">-->
+<!--        <div id="renewable_share_scenario_chart" class="goal-chart"></div>-->
+<!--      </div>-->
+<!--    </div>-->
+<!--    <div class="panel__chart">-->
+<!--      <div class="panel__chart-title">-->
+<!--       {% translate "THG-Reduktion ggü. 2019 (%)" %}-->
+<!--      </div>-->
+<!--      <div class="panel__chart-content">-->
+<!--        <div id="co2_emissions_scenario_chart" class="goal-chart"></div>-->
+<!--      </div>-->
+<!--    </div>-->
+<!--  </div>-->
+<!--</div>-->
 <div class="panel__settings panel__settings--padding">
   <div class="panel-item">
     <h2 class="panel-item__heading panel-item__heading--nopadding">


### PR DESCRIPTION
Fixes #337

Hey @henhuy, main charts today and results are hidden now:

- I updated the templates and JS by commenting-out to reactivate if needed in future apps
- I did not touch the (old) `charts.js`
- I did not touch the `charts.py`. Dunno if you wanna make changes here..

Feel free to merge if you think these measures are sufficient.