### PR TITLE
Improve oemof simulation runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 
 ### Changed
 - Remove locale EN
+- Abort simulation run when switching to settings tab
 
 ### Fixed
 - various fixes in charts, texts and units

--- a/digiplan/static/js/menu.js
+++ b/digiplan/static/js/menu.js
@@ -29,6 +29,7 @@ PubSub.subscribe(eventTopics.MENU_STATUS_QUO_SELECTED, hidePotentialLayers);
 PubSub.subscribe(eventTopics.MENU_SETTINGS_SELECTED, setMapChartViewVisibility);
 PubSub.subscribe(eventTopics.MENU_SETTINGS_SELECTED, showMapView);
 PubSub.subscribe(eventTopics.MENU_SETTINGS_SELECTED, deactivateChoropleth);
+PubSub.subscribe(eventTopics.MENU_SETTINGS_SELECTED, terminateSimulation);
 PubSub.subscribe(eventTopics.MENU_RESULTS_SELECTED, setMapChartViewVisibility);
 PubSub.subscribe(eventTopics.MENU_RESULTS_SELECTED, hidePotentialLayers);
 PubSub.subscribe(eventTopics.MAP_VIEW_SELECTED, setResultsView);
@@ -100,6 +101,21 @@ function setResultsView(msg) {
         futureDropdown.parentElement.setAttribute("style", "");
         regionChart.setAttribute("style", "");
         resultsTabs.parentElement.setAttribute("style", "display: none !important");
+    }
+    return logMessage(msg);
+}
+
+function terminateSimulation(msg) {
+    if (store.cold.task_id != null) {
+        $.ajax({
+            url: "/oemof/terminate",
+            type: "POST",
+            data: {task_id: store.cold.task_id},
+            success: function () {
+                store.cold.task_id = null;
+            }
+        });
+        document.getElementById("simulation_spinner").hidden = true;
     }
     return logMessage(msg);
 }

--- a/digiplan/static/js/results.js
+++ b/digiplan/static/js/results.js
@@ -97,6 +97,11 @@ function checkResults() {
                 map_store.cold.state.simulation_id = json.simulation_id;
                 PubSub.publish(eventTopics.SIMULATION_FINISHED);
             }
+        },
+        error: function(json) {
+            store.cold.task_id = null;
+            map_store.cold.state.simulation_id = null;
+            PubSub.publish(eventTopics.SIMULATION_FINISHED);
         }
     });
 }

--- a/digiplan/static/js/results.js
+++ b/digiplan/static/js/results.js
@@ -44,8 +44,6 @@ futureDropdown.addEventListener("change", function() {
 PubSub.subscribe(eventTopics.MENU_RESULTS_SELECTED, simulate);
 PubSub.subscribe(eventTopics.MENU_RESULTS_SELECTED, showSimulationSpinner);
 PubSub.subscribe(eventTopics.SIMULATION_STARTED, checkResultsPeriodically);
-// PubSub.subscribe(eventTopics.SIMULATION_STARTED, hideResultButtons);
-// PubSub.subscribe(eventTopics.SIMULATION_FINISHED, showResultButtons);
 PubSub.subscribe(eventTopics.SIMULATION_FINISHED, showResults);
 PubSub.subscribe(eventTopics.SIMULATION_FINISHED, hideSimulationSpinner);
 PubSub.subscribe(eventTopics.SIMULATION_FINISHED, showResultCharts);
@@ -63,6 +61,9 @@ function simulate(msg) {
             url : "/oemof/terminate",
             type : "POST",
             data : {task_id: store.cold.task_id},
+            success: function() {
+                store.cold.task_id = null;
+            }
         });
     }
     $.ajax({

--- a/poetry.lock
+++ b/poetry.lock
@@ -1192,7 +1192,7 @@ resolved_reference = "14204e2ee3bc5e8146c17928b68130832be6e63b"
 
 [[package]]
 name = "django-oemof"
-version = "0.14.0"
+version = "0.15.0"
 description = "Django application to run oemof"
 optional = false
 python-versions = "^3.9"
@@ -1210,7 +1210,7 @@ djangorestframework = "^3.14.0"
 type = "git"
 url = "https://github.com/rl-institut/django-oemof.git"
 reference = "HEAD"
-resolved_reference = "05f595d95c2d2c83c770d52a12b9bd0222bb6925"
+resolved_reference = "e982e4510fc855e0296544fa7a5370430ba89ff4"
 
 [[package]]
 name = "django-redis"


### PR DESCRIPTION
Changed following behaviour:
- result is not stored if simulation with same parameters already exists (checked after simulating results - this prevents double entries if simulations with same parameters run in parallel)
- result is not stored if optimization is infeasible

Infeasbile optimization run now throws an APIException error which is handled in digiplan here:
https://github.com/rl-institut-private/digiplan/blob/30ddeb9dc27c5e7042177ddf916c4065eb01ff5f/digiplan/static/js/results.js#L101

**Note**: I did not test whats happening on client side if simulation finishes with infeasible results! As `SIMULATION_FINISHED` event is fired with non valid simulation id this will lead to errors. Should be handled somehow - but I had not time to built an infeasible optimization problem...