### PR TITLE
Fix population popups for missing data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - Abort simulation run when switching to settings tab
 
 ### Fixed
+- population popups for missing data
 - various fixes in charts, texts and units
 - RES share calculation for SQ
 - power and heat demand scaling for future scenario

--- a/digiplan/map/popups.py
+++ b/digiplan/map/popups.py
@@ -5,6 +5,7 @@ from collections import namedtuple
 from collections.abc import Iterable
 from typing import Optional, Union
 
+import numpy as np
 import pandas as pd
 from django.db.models import F
 from django.utils.translation import gettext_lazy as _
@@ -68,6 +69,7 @@ class RegionPopup(popups.ChartPopup):
             chart data ready to use in ECharts in JS
         """
         chart_data = self.get_chart_data()
+        chart_data = chart_data.replace([np.nan], [None])
         return charts.create_chart(self.lookup, chart_data)
 
     @abc.abstractmethod


### PR DESCRIPTION
Problem was, that data for 2010 in both municialities is not given and `np.nan` produce an error in echarts.
Replacing `np.nan` with `None` allows e-charts to print chart data.
Nevertheless, we should add missing values for year 2010.